### PR TITLE
Select 1 measurement per each timeline when the limit option is used.

### DIFF
--- a/app/controllers/api/v1/measurements_controller.rb
+++ b/app/controllers/api/v1/measurements_controller.rb
@@ -33,16 +33,30 @@ module Api
         end
 
         if params.keys.include? "limit"
-          case params[:limit]
-            when 'first'
-              query = query.where(filter).order(:timestamp)
-            respond_with [query.first]
-            when 'last'
-              query = query.where(filter).order(:timestamp)
-            respond_with [query.last]
+          result = []
+          timelines = []
+          if params[:limit] == 'first'
+            query = query.where(filter).includes(:timeline).order('timestamp ASC')
+          else
+            query = query.where(filter).includes(:timeline).order('timestamp DESC')
           end
+
+          query.each do |m|
+            if timelines.include? m.timeline
+              # Do nothing
+            else
+              result << m
+              timelines << m.timeline
+            end
+          end
+          respond_with result
         else
-          respond_with query.where(filter).order(:id)
+          query = query.where(filter).order(:id)
+          if query.blank?
+            respond_with []
+          else
+            respond_with query
+          end
         end
       end
 

--- a/spec/requests/api/measurements_spec.rb
+++ b/spec/requests/api/measurements_spec.rb
@@ -152,13 +152,15 @@ describe Api::V1::MeasurementsController do
     end
 
     context 'return first and last measurements when requested' do
-      let(:t) { create(:timeline) }
+      let(:t1) { create(:timeline) }
+      let(:t2) { create(:timeline) }
+      let(:t3) { create(:timeline) }
 
       it 'properly returns first measurement' do
         time = Time.now
         ms = []
         for i in 1..10 do
-          ms << create(:measurement, timeline: t, timestamp: time+i.seconds)
+          ms << create(:measurement, timeline: t1, timestamp: time+i.seconds)
         end
 
         get api("/measurements?limit=first", user)
@@ -170,7 +172,7 @@ describe Api::V1::MeasurementsController do
         time = Time.now
         ms = []
         for i in 1..10 do
-          ms << create(:measurement, timeline: t, timestamp: time+i.seconds)
+          ms << create(:measurement, timeline: t1, timestamp: time+i.seconds)
         end
 
         get api("/measurements?limit=last", user)
@@ -178,11 +180,33 @@ describe Api::V1::MeasurementsController do
         expect(ms_response.collect{|r| r['id']}).to include ms.last.id
       end
 
+      it 'properly returns one measurement per timeline' do
+        time = Time.now
+        ms1, ms2, ms3 = [], [], []
+        for i in 1..10 do
+          ms1 << create(:measurement, timeline: t1, timestamp: time+i.seconds)
+          ms2 << create(:measurement, timeline: t2, timestamp: time+(i*5).seconds)
+          ms3 << create(:measurement, timeline: t3, timestamp: time+(i*100).seconds)
+        end
+
+        get api("/measurements?limit=first", user)
+        expect(ms_response.length).to eq 3
+        expect(ms_response.collect{|r| r['id']}).to include ms1.first.id
+        expect(ms_response.collect{|r| r['id']}).to include ms2.first.id
+        expect(ms_response.collect{|r| r['id']}).to include ms3.first.id
+
+        get api("/measurements?limit=last", user)
+        expect(ms_response.length).to eq 3
+        expect(ms_response.collect{|r| r['id']}).to include ms1.last.id
+        expect(ms_response.collect{|r| r['id']}).to include ms2.last.id
+        expect(ms_response.collect{|r| r['id']}).to include ms3.last.id
+      end
+
       it 'properly returns first and last measurements when time_from and time_to are used' do
         time = Time.now
         ms = []
         for i in 1..10 do
-          ms << create(:measurement, timeline: t, timestamp: time+i.seconds)
+          ms << create(:measurement, timeline: t1, timestamp: time+i.seconds)
         end
 
         get api("/measurements?time_from=#{URI::encode((time+3.seconds).to_s)}&time_to=#{URI::encode((time+7.seconds).to_s)}&limit=first", user)
@@ -191,6 +215,16 @@ describe Api::V1::MeasurementsController do
         expect(ms_response.collect{|r| r['id']}).to include ms[5].id
       end
 
+      it 'returns an empty table when no results are found' do
+        time = Time.now
+        ms = []
+        for i in 1..10 do
+          ms << create(:measurement, timeline: t1, timestamp: time+i.seconds)
+        end
+
+        get api("/measurements?time_from=#{URI::encode((time+20.seconds).to_s)}&time_to=#{URI::encode((time+30.seconds).to_s)}&limit=first", user)
+        expect(ms_response).to eq []
+      end
     end
   end
 


### PR DESCRIPTION
Also fixes null value returned when no measurements are found.