### PR TITLE
Eager load device dependencies to speedup serialization

### DIFF
--- a/app/controllers/api/v1/devices_controller.rb
+++ b/app/controllers/api/v1/devices_controller.rb
@@ -5,7 +5,11 @@ module Api
       respond_to :json
 
       def index
-        respond_with @devices.where(filter).order(:id)
+        respond_with(@devices.
+                     includes(:budokop_sensor, :neosentio_sensor, :pump,
+                              :weather_station, :fiber_optic_node, :parameters).
+                     where(filter).
+                     order(:id))
       end
 
       def show


### PR DESCRIPTION
Fix #43

Let's do some benchmarking:

```ruby
require 'benchmark'

Benchmark.bm do |bm|
  bm.report('without include') do
    Device.all.map { |d| DeviceSerializer.new(d).to_json }
  end
  bm.report('with include') do
    Device.includes(:budokop_sensor, :neosentio_sensor, :pump,
:weather_station, :fiber_optic_node, :parameters).all.map { |d|
DeviceSerializer.new(d).to_json }
  end
end
```

The results show huge speed improvement:

```
      user     system      total        real
  3.760000   0.140000   3.900000 (  4.547777)
  0.660000   0.000000   0.660000 (  0.668563)
```