### PR TITLE
Parameter includes to improve serialization

### DIFF
--- a/app/controllers/api/v1/parameters_controller.rb
+++ b/app/controllers/api/v1/parameters_controller.rb
@@ -12,7 +12,9 @@ module Api
           query = query.where(id: ids)
         end
 
-        respond_with query.where(filter).order(:id)
+        respond_with(query.
+                     includes(:measurement_type, :timelines).
+                     where(filter).order(:id))
       end
 
       def show


### PR DESCRIPTION
Let's do some benchmarking:

```ruby
require 'benchmark'

Benchmark.bm do |bm|
  bm.report('without include') do
    Parameter.all.map { |p| ParameterSerializer.new(p).to_json }
  end
  bm.report('with include') do
    Parameter.includes(:measurement_type, :timelines).all.map { |p|
ParameterSerializer.new(p).to_json }
  end
end
```

The results shows huge speed improvement:

```
       user     system      total        real
   1.580000   0.070000   1.650000 (  1.797415)
   0.380000   0.000000   0.380000 (  0.391085)
```