### PR TITLE
Remove section number from budocop device custom_id

### DIFF
--- a/lib/tasks/budokop_remove_section_from_custom_id.rake
+++ b/lib/tasks/budokop_remove_section_from_custom_id.rake
@@ -1,0 +1,11 @@
+namespace :budokop do
+  task remove_section_from_custom_id: :environment do
+    budokop_devices =
+      Device.where("device_type='budokop-sensor' AND custom_id LIKE '_ %'")
+    ActiveRecord::Base.transaction do
+      budokop_devices.find_each do |device|
+        device.update_attribute(:custom_id, device.custom_id[2..-1])
+      end
+    end
+  end
+end


### PR DESCRIPTION
For all budokop sensors with `the custom_id` schema equals to `_ %` following update is made:
  - `X UTYY` -> `UTYY`
  - `X SVY`   -> `SVY`