### PR TITLE
Generate device aggregation custom_id

### DIFF
--- a/lib/tasks/device_aggregations.rake
+++ b/lib/tasks/device_aggregations.rake
@@ -1,0 +1,12 @@
+namespace :device_aggregations do
+  task generate_name: :environment do
+    DeviceAggregation.eager_load(:devices).all.find_each do |aggregat|
+      name = aggregat.devices.each_with_object([]) do |device, names|
+        names << device.custom_id
+      end.join(', ')
+
+      name =  (name.empty? ? 'Empty' : name).truncate(255, separator: ', ')
+      aggregat.update_attribute(:custom_id, name)
+    end
+  end
+end


### PR DESCRIPTION
Device aggregation custom_id is generated basing on attached to this aggregation list of devices. If the name is too long (more than 255 chars) than it is truncated and at the end `...` are added.